### PR TITLE
Update deft.el

### DIFF
--- a/deft.el
+++ b/deft.el
@@ -954,7 +954,7 @@ Otherwise, quick create a new file."
      ((widget-at)
       (widget-button-press (point)))
      ;; Active filter string with match
-     ((and deft-filter-regexp (setq first-match (deft-first-matching-file)))
+     ((and deft-filter-regexp (setq first-match (deft-first-matching-file deft-current-files)))
       (deft-open-file first-match))
      ;; Default
      (t


### PR DESCRIPTION
Fixed error when creating new file without doing C-c C-n.

Wrong number of parameters to deft-first-matching-file (file-list) in deft-complete.
